### PR TITLE
Decode numberic character references (decimal/hexadecimal)

### DIFF
--- a/lib/html_entities.ex
+++ b/lib/html_entities.ex
@@ -8,12 +8,14 @@ defmodule HtmlEntities do
       "Tom & Jerry"
       iex> "&#161;Ay, caramba!" |> HtmlEntities.decode
       "¡Ay, caramba!"
+      iex> "&#337; &#x151;" |> HtmlEntities.decode
+      "ő ő"
   """
 
   @doc "Decode HTML entities in a string."
   @spec decode(String.t) :: String.t
   def decode(string) do
-    Regex.replace(~r/\&[^\s]+;/r, string, &replace_entity/1)
+    Regex.replace(~r/\&([^\s]+);/r, string, &replace_entity/2)
   end
 
   html_entities_list_path = Path.join(__DIR__, "html_entities_list.txt")
@@ -27,7 +29,16 @@ defmodule HtmlEntities do
   for {name, character, codepoint} <- codes do
     entity = "&#{name};"
     codepoint_entity = "&##{codepoint};"
-    defp replace_entity(unquote(entity)), do: unquote(character)
-    defp replace_entity(unquote(codepoint_entity)), do: unquote(character)
+    defp replace_entity(unquote(entity), _), do: unquote(character)
+    defp replace_entity(unquote(codepoint_entity), _), do: unquote(character)
+  end
+
+  defp replace_entity(_, "#x" <> code) do
+    {i, _} = Code.eval_string("0x#{code}", [], __ENV__)
+    << i :: utf8 >>
+  end
+
+  defp replace_entity(_, "#" <> code) do
+    << String.to_integer(code) :: utf8 >>
   end
 end

--- a/lib/html_entities.ex
+++ b/lib/html_entities.ex
@@ -34,8 +34,7 @@ defmodule HtmlEntities do
   end
 
   defp replace_entity(_, "#x" <> code) do
-    {i, _} = Code.eval_string("0x#{code}", [], __ENV__)
-    << i :: utf8 >>
+    << String.to_integer(code, 16) :: utf8 >>
   end
 
   defp replace_entity(_, "#" <> code) do


### PR DESCRIPTION
I've changed the regex to capture the codepoint inside (without the '&''
prefix and ';' suffix). Because of that I had to change the arity of the
replace_entity function to 2. The original two declarations ignore the
second argument.

I added two replace_entity declarations. The first handles the
hexadecimal numberic character references, the second the decimal ones.
The way the hexadecimal value is turned into an integer should be
maybe changed to something more elegant.