### PR TITLE
Refactor entity replacement code generation

### DIFF
--- a/lib/html_entities.ex
+++ b/lib/html_entities.ex
@@ -20,10 +20,7 @@ defmodule HtmlEntities do
     Regex.replace(~r/\&([^\s]+);/r, string, &replace_entity/2)
   end
 
-  codes = File.stream!(@external_resource) |> Enum.reduce [], fn(line, acc) ->
-    [name, character, codepoint] = line |> String.rstrip |> String.split ","
-    :lists.keystore(name, 1, acc, {name, character, codepoint})
-  end
+  codes = HtmlEntities.Util.load_entities(@external_resource)
 
   for {name, character, codepoint} <- codes do
     defp replace_entity(_, unquote(name)), do: unquote(character)

--- a/lib/html_entities/util.ex
+++ b/lib/html_entities/util.ex
@@ -1,0 +1,27 @@
+defmodule HtmlEntities.Util do
+  @moduledoc """
+  Utility functions for managing metadata.
+
+  Putting this code here makes it testable, and allows the code
+  generation part of HtmlEntities to be as small as possible.
+  """
+
+  @type entity :: {String.t, String.t, String.t}
+
+  @doc "Load HTML entities from an external file."
+  @spec load_entities(String.t) :: [entity]
+  def load_entities(filename) do
+    File.stream!(filename) |> convert_lines_to_entities
+  end
+
+  @doc "Convert a list of comma-separated lines to entity definitions."
+  @spec convert_lines_to_entities([String.t]) :: [entity]
+  def convert_lines_to_entities(lines) do
+    Enum.reduce(lines, [], &add_entity_to_list/2)
+  end
+
+  defp add_entity_to_list(line, list) do
+    [name, character, codepoint] = line |> String.rstrip |> String.split(",")
+    :lists.keystore(name, 1, list, {name, character, codepoint})
+  end
+end

--- a/lib/html_entities/util.ex
+++ b/lib/html_entities/util.ex
@@ -15,7 +15,7 @@ defmodule HtmlEntities.Util do
   end
 
   @doc "Convert a list of comma-separated lines to entity definitions."
-  @spec convert_lines_to_entities([String.t]) :: [entity]
+  @spec convert_lines_to_entities([String.t] | File.Stream.t) :: [{String.t, String.t, String.t}]
   def convert_lines_to_entities(lines) do
     Enum.reduce(lines, [], &add_entity_to_list/2)
   end

--- a/test/html_entities/util_test.exs
+++ b/test/html_entities/util_test.exs
@@ -1,0 +1,27 @@
+defmodule HtmlEntitiesUtilTest do
+  use ExUnit.Case
+  doctest HtmlEntities.Util
+  import HtmlEntities.Util
+
+  test "Comma-separated entity descriptions are converted to tuples" do
+    entity_defs = ["auml,ä,228", "aring,å,229", "ouml,ö,246"]
+
+    assert convert_lines_to_entities(entity_defs) == [
+      {"auml", "ä", "228"},
+      {"aring", "å", "229"},
+      {"ouml", "ö", "246"}
+    ]
+  end
+
+  test "Structurally invalid entity descriptions trigger an error" do
+    assert_raise MatchError, fn ->
+      convert_lines_to_entities(["auml,ä,228,foo"])
+    end
+    assert_raise MatchError, fn ->
+      convert_lines_to_entities(["auml,ä"])
+    end
+    assert_raise MatchError, fn ->
+      convert_lines_to_entities([""])
+    end
+  end
+end


### PR DESCRIPTION
Split out loading of entity definitions from an external file
into separate functions in a new `HtmlEntities.Utils` module.

This simultaneously fixes some Elixir 1.2 warnings regarding
piping into function calls without parentheses, and makes the
core part of entity definition loading testable.