### PR TITLE
encode_once method to prevent double encoding

### DIFF
--- a/lib/html_entities.ex
+++ b/lib/html_entities.ex
@@ -37,6 +37,14 @@ defmodule HtmlEntities do
     |> Enum.join()
   end
 
+  # From https://github.com/rails/rails/blob/master/activesupport%2Flib%2Factive_support%2Fcore_ext%2Fstring%2Foutput_safety.rb
+  @html_escape_once_regexp ~r/["><']|&(?!([a-zA-Z]+|(#\d+)|(#[xX][\dA-Fa-f]+));)/
+  @doc "Encode HTML entities in a string ensuring entities are not double encoded (ex: &amp;amp;)."
+  @spec encode_once(String.t) :: String.t
+  def encode_once(string) do
+    Regex.replace(@html_escape_once_regexp, string, &replace_character/1)
+  end
+
   codes = HtmlEntities.Util.load_entities(@external_resource)
 
   for {name, character, codepoint} <- codes do
@@ -58,7 +66,7 @@ defmodule HtmlEntities do
 
   defp replace_entity(original, _), do: original
 
-  defp replace_character("'"), do: "&apos;"
+  defp replace_character("'"), do: "&#39;"
   defp replace_character("\""), do: "&quot;"
   defp replace_character("&"), do: "&amp;"
   defp replace_character("<"), do: "&lt;"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HtmlEntities.Mixfile do
   def project do
     [
       app: :html_entities,
-      version: "0.4.0",
+      version: "0.5.0",
       name: "HtmlEntities",
       source_url: "https://github.com/martinsvalin/html_entities",
       elixir: "~> 1.3",

--- a/test/html_entities_test.exs
+++ b/test/html_entities_test.exs
@@ -18,6 +18,10 @@ defmodule HtmlEntitiesTest do
   end
 
   test "Encoding does replace unsafe characters" do
-    assert encode("'\"&<>") == "&apos;&quot;&amp;&lt;&gt;"
+    assert encode("'\"&<>") == "&#39;&quot;&amp;&lt;&gt;"
+  end
+
+  test "encode_once does not double encode entities" do
+    assert encode_once(encode("'\"&<>")) == "&#39;&quot;&amp;&lt;&gt;"
   end
 end


### PR DESCRIPTION
Thoughts on adding an `encode_once` method to prevent `&amp;amp; &amp;lt;` type scenarios?

Also changed from `&apos;` to `&#39;` to match but that seems debatable.

Concept from https://github.com/rails/rails/blob/master/activesupport%2Flib%2Factive_support%2Fcore_ext%2Fstring%2Foutput_safety.rb