### PR TITLE
Streamline decoding and encoding

### DIFF
--- a/lib/html_entities/util.ex
+++ b/lib/html_entities/util.ex
@@ -11,17 +11,13 @@ defmodule HtmlEntities.Util do
   @doc "Load HTML entities from an external file."
   @spec load_entities(String.t) :: [entity]
   def load_entities(filename) do
-    File.stream!(filename) |> convert_lines_to_entities
+    File.stream!(filename) |> Enum.map(&convert_line_to_entity/1)
   end
 
-  @doc "Convert a list of comma-separated lines to entity definitions."
-  @spec convert_lines_to_entities([String.t] | File.Stream.t) :: [{String.t, String.t, String.t}]
-  def convert_lines_to_entities(lines) do
-    Enum.reduce(lines, [], &add_entity_to_list/2)
-  end
-
-  defp add_entity_to_list(line, list) do
+  @doc "Converts a line of comma-separated lines to entity definitions."
+  @spec convert_line_to_entity([String.t] | File.Stream.t) :: [{String.t, String.t, String.t}]
+  def convert_line_to_entity(line) do
     [name, character, codepoint] = line |> String.trim_trailing |> String.split(",")
-    :lists.keystore(name, 1, list, {name, character, codepoint})
+    {name, character, codepoint}
   end
 end

--- a/test/html_entities/util_test.exs
+++ b/test/html_entities/util_test.exs
@@ -4,28 +4,24 @@ defmodule HtmlEntitiesUtilTest do
   import HtmlEntities.Util
 
   test "Comma-separated entity descriptions are converted to tuples" do
-    entity_defs = ["auml,ä,228", "aring,å,229", "ouml,ö,246"]
-
-    assert convert_lines_to_entities(entity_defs) == [
-      {"auml", "ä", "228"},
-      {"aring", "å", "229"},
-      {"ouml", "ö", "246"}
-    ]
+    assert convert_line_to_entity("auml,ä,228") == {"auml", "ä", "228"}
+    assert convert_line_to_entity("aring,å,229") == {"aring", "å", "229"}
+    assert convert_line_to_entity("ouml,ö,246") == {"ouml", "ö", "246"}
   end
 
   test "Structurally invalid entity descriptions trigger an error" do
     assert_raise MatchError, fn ->
-      convert_lines_to_entities(["auml,ä,228,foo"])
+      convert_line_to_entity("auml,ä,228,foo")
     end
     assert_raise MatchError, fn ->
-      convert_lines_to_entities(["auml,ä"])
+      convert_line_to_entity("auml,ä")
     end
     assert_raise MatchError, fn ->
-      convert_lines_to_entities([""])
+      convert_line_to_entity("")
     end
   end
 
   test "Trailing whitespace is removed from entity descriptions" do
-    assert convert_lines_to_entities(["euro,€,8364 \t"]) == [{"euro","€","8364"}]
+    assert convert_line_to_entity("euro,€,8364 \t") == {"euro","€","8364"}
   end
 end

--- a/test/html_entities_test.exs
+++ b/test/html_entities_test.exs
@@ -13,6 +13,11 @@ defmodule HtmlEntitiesTest do
     assert decode("&#xxxx;") == "&#xxxx;"
   end
 
+  test "Decoding numbers" do
+    assert decode("perhaps an &#x26;?") == "perhaps an &?"
+    assert decode("perhaps an &#38;?") == "perhaps an &?"
+  end
+
   test "Encoding doesn't replace safe UTF-8 characters" do
     assert encode("AbcÅäö€") == "AbcÅäö€"
   end


### PR DESCRIPTION
This PR replaces the regex and graphemes in favor
of binary matching. This makes decoding 10x faster and
encoding around 7x faster.

The PR also makes it so we don't load all entities into
memory when parsing the file but this is mostly likely
irrelevant since the file is quite small.

Thank you for reading and for maintaining the project! :heart: