### PR TITLE
Prefer using hex entity for apostrophe instead of &apos;

### DIFF
--- a/lib/html_entities.ex
+++ b/lib/html_entities.ex
@@ -77,7 +77,7 @@ defmodule HtmlEntities do
   def encode(string) when is_binary(string) do
     for <<x <- string>>, into: "" do
       case x do
-        ?' -> "&apos;"
+        ?' -> "&#39;"
         ?" -> "&quot;"
         ?& -> "&amp;"
         ?< -> "&lt;"

--- a/test/html_entities_test.exs
+++ b/test/html_entities_test.exs
@@ -36,7 +36,7 @@ defmodule HtmlEntitiesTest do
     end
 
     test "replace unsafe characters" do
-      assert encode("'\"&<>") == "&apos;&quot;&amp;&lt;&gt;"
+      assert encode("'\"&<>") == "&#39;&quot;&amp;&lt;&gt;"
     end
   end
 end


### PR DESCRIPTION
As recommended by [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html), using `&apos;` in HTML documents is not safe.